### PR TITLE
Fixed shaders compilation on OS X

### DIFF
--- a/shaders/trees_sway.fp
+++ b/shaders/trees_sway.fp
@@ -6,6 +6,6 @@ const float sway_ammount = 0.02;
 vec4 Process(vec4 color)
 {
 	vec2 t = gl_TexCoord[0].st;
-  t.x += sin(pi * 0.5 * (t.y + timer * 0.5)) * sway_ammount * max(0, 0.6 - t.y);
+  t.x += sin(pi * 0.5 * (t.y + timer * 0.5)) * sway_ammount * max(0.0, 0.6 - t.y);
   return getTexel(t) * color;
 }


### PR DESCRIPTION
No more `No matching function for call to max(int, float)` errors
Apple's shader compiler is much more strict than vendor specific one on Windows