### PR TITLE
MODELDEF: Fix laser beam orientation

### DIFF
--- a/modeldef.txt
+++ b/modeldef.txt
@@ -4055,9 +4055,10 @@ Model LaserBeam_Red
 	Model 0 "kodilazer.md3"
 	Skin 0 "kodilazer1.jpg"
 	Scale 1.0 1.0 1.0
-	InheritActorPitch
+	PitchOffset 180
+	// Offset -4 0 0	// compromise between the laser model position and the impact decal position.
 	InheritActorRoll
-	PITCHFROMMOMENTUM
+	InheritActorPitch
 
 	FrameIndex UNKN A 0 0
 }
@@ -4068,9 +4069,10 @@ Model LaserBeam_Purple
 	Model 0 "kodilazer.md3"
 	Skin 0 "kodilazer2.jpg"
 	Scale 1.0 1.0 1.0
-	InheritActorPitch
+	PitchOffset 180
+	// Offset -4 0 0	// compromise between the laser model position and the impact decal position.
 	InheritActorRoll
-	PITCHFROMMOMENTUM
+	InheritActorPitch
 
 	FrameIndex UNKN A 0 0
 }
@@ -4081,9 +4083,10 @@ Model LaserBeam_Green
 	Model 0 "kodilazer.md3"
 	Skin 0 "kodilazer3.jpg"
 	Scale 1.0 1.0 1.0
-	InheritActorPitch
+	PitchOffset 180
+	// Offset -4 0 0	// compromise between the laser model position and the impact decal position.
 	InheritActorRoll
-	PITCHFROMMOMENTUM
+	InheritActorPitch
 
 	FrameIndex UNKN A 0 0
 }


### PR DESCRIPTION
I don't know if this is a bug on my end or not, but the laser beams were being displayed backwards. This pull request fixes this issue.