### PR TITLE
Fix flinch interfering with Firebrand's super alt-fire accuracy

### DIFF
--- a/actors/weapons/firebrand.txt
+++ b/actors/weapons/firebrand.txt
@@ -114,8 +114,8 @@ ACTOR Firebrand : NaziWeapon
 		SRDG DE 1
 		SRDF F 1 A_PlaySound("flamesword/swing")
 		"####" GH 1
-		"####" I 1 Thing_Damage(0,2)
-		"####" J 1 A_FireCustomMissile("FirebrandFireball")
+		"####" I 1
+		"####" J 1 { A_FireCustomMissile("FirebrandFireball"); Thing_Damage(0,2); }
 		"####" KLM 1
 		TNT1 A 20 A_WeaponReady
 		SRDF C 1


### PR DESCRIPTION
Currently, the Firebrand's super alt-fire hurts the player and then fires a projectile. This ordering causes the fireball to be shot off-target as it is fired during a flinch. To fix the issue, this pull makes the player take damage after the projectile is shot.

But maybe the Firebrand shouldn't cause the player to flinch at all. If that's the case, I can rework the flinch script to ignore certain damage types.