### PR TITLE
Use absolute paths to avoid conflicts with relative paths

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -206,7 +206,7 @@ REM     CompressionLevel [int]
 REM             Upholds the compression level of the archive file.  Range is from 0-9
 REM ================================================================================================
 :CompactProject_Execute
-tools\7za a -t%1 -mm=%2 -mx=%3 -x@".\tools\7zExcludeListDir.txt" -xr@".\tools\7zExcludeList.txt" ..\wolf_boa.pk3 *
+"%ProgramDirPath%\tools\7za.exe" a -t%1 -mm=%2 -mx=%3 -x@"%ProgramDirPath%\tools\7zExcludeListDir.txt" -xr@"%ProgramDirPath%\tools\7zExcludeList.txt" "%ProgramDirPath%\..\wolf_boa.pk3" "%ProgramDirPath%\*"
 EXIT /B 0
 
 


### PR DESCRIPTION
Using absolute paths will lock the program to using  the appripriate and intended external tools and external resources.  If using relative paths, there could potentially be a risk of causing unintential tasks.  The best example, if user's working directory is set at "C:\Windows\System32", but the program we want is in "G:\WolfenDoom", the program is going to use  the relative paths of "C:\Windows\System32\" instead of "G:\WolfenDoom".