### PR TITLE
Stability and mild updates

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -154,15 +154,15 @@ REM ============================================================================
 SET "ErrorString="
 SET "ErrorBool=False"
 REM Try to check if the resources could be found; if not - prepare an error message.
-IF NOT EXIST "%ProgramDirPath%\tools\7za.exe" (
+IF NOT EXIST "%ProgramDirPath%tools\7za.exe" (
     SET ErrorBool=True
     SET "ErrorString=%ErrorString%Could Not Find 7Zip!&ECHO."
 )
-IF NOT EXIST "%ProgramDirPath%\tools\7zExcludeListDir.txt" (
+IF NOT EXIST "%ProgramDirPath%tools\7zExcludeListDir.txt" (
     SET ErrorBool=True
     SET "ErrorString=%ErrorString%Could Not Find Exclude Directory List!&ECHO."
 )
-IF NOT EXIST "%ProgramDirPath%\tools\7zExcludeList.txt" (
+IF NOT EXIST "%ProgramDirPath%tools\7zExcludeList.txt" (
     SET ErrorBool=True
     SET "ErrorString=%ErrorString%Could Not Find Exclude List!&ECHO."
 )

--- a/build.bat
+++ b/build.bat
@@ -219,7 +219,39 @@ REM                 notice that their normal activities will be greatly delayed 
 REM ================================================================================================
 :CompactProject_Execute
 START "WolfenDoom Compile: 7Zip" /B /%4 /WAIT "%ProgramDirPath%\tools\7za.exe" a -t%1 -mm=%2 -mx=%3 -x@"%ProgramDirPath%\tools\7zExcludeListDir.txt" -xr@"%ProgramDirPath%\tools\7zExcludeList.txt" "%ProgramDirPath%\..\wolf_boa.pk3" "%ProgramDirPath%\*"
-EXIT /B 0
+REM Because I couldn't use the error-pipes with 'Start', we'll have to check the ExitCode in a conditional statement
+IF %ERRORLEVEL% GEQ 1 (
+    CALL :CompactProject_Execute_ErrMSG %ERRORLEVEL%
+    EXIT /B 1
+) ELSE (
+    EXIT /B 0
+)
+
+
+
+
+REM ================================================================================================
+REM Documentation
+REM     If 7Zip returned an error, let the user know that the process was terminated prematurely or failed.
+REM Parameters
+REM     ExitCode [Int] = %1
+REM             Holds the value of the ExitCode from 7Zip
+REM ================================================================================================
+:CompactProject_Execute_ErrMSG
+ECHO.
+ECHO CRITICAL ERROR: 7ZIP FAILED!
+ECHO 7Zip was unable to complete the operation and closed with an Exit Code: %1.
+ECHO.
+ECHO Tips:
+ECHO  * Make sure you have enough permission to run applications.
+ECHO  * Does the project file already exist?  If so, please delete it and try again.
+ECHO  * Make sure that the system has enough memory to perform the operation.
+ECHO  * Make sure that the files are not locked by other applications.
+ECHO  * Examine any warning messages provided and try to address them as much as possible.
+ECHO.
+ECHO If this issue reoccurs please let us know.
+PAUSE
+GOTO :EOF
 
 
 

--- a/build.bat
+++ b/build.bat
@@ -218,7 +218,7 @@ REM                 of the program that has the 'RealTime' flag.  Meaning, if ex
 REM                 notice that their normal activities will be greatly delayed until the program with 'RealTime' is completed.
 REM ================================================================================================
 :CompactProject_Execute
-START "WolfenDoom Compile: 7Zip" /B /%4 /WAIT "%ProgramDirPath%\tools\7za.exe" a -t%1 -mm=%2 -mx=%3 -x@"%ProgramDirPath%\tools\7zExcludeListDir.txt" -xr@"%ProgramDirPath%\tools\7zExcludeList.txt" "%ProgramDirPath%\..\wolf_boa.pk3" "%ProgramDirPath%\*"
+START "WolfenDoom Compile: 7Zip" /B /%4 /WAIT "%ProgramDirPath%tools\7za.exe" a -t%1 -mm=%2 -mx=%3 -x@"%ProgramDirPath%tools\7zExcludeListDir.txt" -xr@"%ProgramDirPath%tools\7zExcludeList.txt" "%ProgramDirPath%..\wolf_boa.pk3" "%ProgramDirPath%*"
 REM Because I couldn't use the error-pipes with 'Start', we'll have to check the ExitCode in a conditional statement
 IF %ERRORLEVEL% GEQ 1 (
     CALL :CompactProject_Execute_ErrMSG %ERRORLEVEL%


### PR DESCRIPTION
Fixed issue where 7Zip was unable to properly update the already built archive data file.
Provide an error message if 7Zip fails during the compiling  phase.
Nit-pick change with '\' during the dependency checks.