### PR TITLE
Fix && Update local GIT repo

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -270,12 +270,14 @@ EXIT /B 0
 REM # ================================================================================================
 REM # Documentation
 REM #     Retrieves and returns the HEAD commit hash of the project.
-REM # Return
-REM #     Project's Commit Hash [String]
+REM #     Sets the value of the commit hash to the variable 'GitCommitHash'.
+REM #      To use this hash in other functions, first call this function and then use the variable
+REM #      %GitCommitHash% in any function.  However, first make sure that the Git dependency is
+REM #      available on the host.
 REM # ================================================================================================
 :GitFeature_FetchCommitHash
 FOR /F %%a IN ('GIT --git-dir=".\.git" rev-parse --short HEAD') DO SET GitCommitHash=%%a
-EXIT /B %GitCommitHash%
+GOTO :EOF
 
 
 

--- a/build.bat
+++ b/build.bat
@@ -284,6 +284,17 @@ GOTO :EOF
 
 REM # ================================================================================================
 REM # Documentation
+REM #     When called, this function will update the master branch of the GIT local repo.
+REM # ================================================================================================
+:GitFeature_UpdateBranch_Master
+GIT --git-dir=".\.git" pull origin master
+GOTO :EOF
+
+
+
+
+REM # ================================================================================================
+REM # Documentation
 REM #     Terminate the program without destroying the console process if invoked via CUI.
 REM # ================================================================================================
 :TerminateProcess


### PR DESCRIPTION
I mistakenly believed that I could return a 'string' but it is only possible to return whole numbers.  The work around - simple - just using the variable within the environment if properly initialized.

Added the feature to update the local Git repo.
However, this feature is NOT yet being referenced.  Thus, the code is not yet used but tested.