### PR TITLE
Fix behaviour of coffee and water machines.

### DIFF
--- a/actors/props/bureau.txt
+++ b/actors/props/bureau.txt
@@ -351,15 +351,17 @@ ACTOR CoffeeMachine : SwitchableDecoration
 	+SHOOTABLE
 	+SOLID
 	+USESPECIAL
-	Activation THINGSPEC_Switch
+	Activation THINGSPEC_Switch | THINGSPEC_ThingTargets
 	States
 	{
 	Active:
-		CUP2 A 0 A_JumpIfInventory("CoffeeCounter", 5, "Empty")
+		CUP2 A 0 A_JumpIfHealthLower(100, 1, AAPTR_TARGET)
+		Goto SpawnSet
+		"####" A 0 A_JumpIfInventory("CoffeeCounter", 5, "Empty")
 		"####" A 0 A_PlaySound("misc/drink", CHAN_AUTO, 1.0, FALSE, ATTN_NORM)
 		GiveHealth:
 		"####" A 1 A_GiveInventory("CoffeeCounter", 1)
-		"####" A 1 A_RadiusGive("Health", 48, RGF_PLAYERS, 1)
+		"####" A 1 A_GiveToTarget("Health", 1)
 		Goto SpawnSet
 	Spawn:
 		CUP2 A 0 NoDelay A_SpawnItemEx("InteractionIcon", ScaleX*4, 0, 0, 0, 0, 0, 0, SXF_SETMASTER | SXF_CLIENTSIDE)
@@ -390,11 +392,13 @@ ACTOR WaterMachine : CoffeeMachine
 	States
 	{
 	Active:
-		WATR A 0 A_JumpIfInventory("WaterCounter", 5, "Empty")
+		WATR A 0 A_JumpIfHealthLower(100, 1, AAPTR_TARGET)
+		Goto SpawnSet
+		"####" A 0 A_JumpIfInventory("WaterCounter", 5, "Empty")
 		"####" A 0 A_PlaySound("misc/drink", CHAN_AUTO, 1.0, FALSE, ATTN_NORM)
 		GiveHealth:
 		"####" A 0 A_GiveInventory("WaterCounter", 1)
-		"####" A 1 A_RadiusGive("Health", 32, RGF_PLAYERS, 1)
+		"####" A 1 A_GiveToTarget("Health", 1)
 		Goto SpawnSet
 	Spawn:
 		WATR A 0 NoDelay A_SpawnItemEx("InteractionIcon", ScaleX*4, 0, 0, 0, 0, 0, 0, SXF_SETMASTER | SXF_CLIENTSIDE)


### PR DESCRIPTION
Set activation property so that coffee and water machines set their target pointer to the player who used it.
Check to see whether the target player has less than 100 health before allowing said player to use the machine.
Heal only the target player instead of all players within 32 or 48 map units.

These changes will make coffee and water machines only heal the player who activates it.

:notebook: I believe this is what the intended behaviour of coffee and water machines is. Correct me if I'm wrong, though...