### PR TITLE
C1M5: Fix occult skull key

### DIFF
--- a/animdefs.txt
+++ b/animdefs.txt
@@ -286,7 +286,7 @@ switch SW_OF_G3 on pic SW_ON_G3 tics 0
 switch SW_OF_HS on pic SW_ON_HS tics 0
 switch SW_OF_P3 on pic SW_ON_P3 tics 0
 switch SW_OF_R3 on pic SW_ON_R3 tics 0
-switch SW_OF_S1 on pic SW_ON_S1 tics 0
+// switch SW_OF_S1 on pic SW_ON_S1 tics 0 // Talon1024 - this texture should be handled in the script, otherwise the occult skull key won't work properly when activated from the inventory.
 switch SW_ON_14 on pic SW_OF_14 tics 0
 switch SW_ON_15 on pic SW_OF_15 tics 0
 switch room_t50 on SOUND SMSWITCH pic room_t63 tics 0


### PR DESCRIPTION
If the player tries to use the occult skull key from his inventory on the door, the script that opens the door will run, but the key slot won't look as if the player has inserted the key into it.
This commit fixes this small nitpick.