### PR TITLE
Refactor Unix build script, and add a couple of features to it.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,21 +1,63 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
+
+separate_hires_pack=0
+
+# Parse arguments
+while [[ $# > 0 ]]; do
+
+  # Help
+  if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    cat <<HELP
+WolfenDoom sh.ake 'n baker - Linux/MacOS build script for
+              WolfenDoom: Blade of Agony
+
+-h    --help      Show this help
+-r    --release   Use LZMA compression instead of Deflate compression
+                  Results in smaller pk3, but takes longer, and cannot be
+                  read or modified using SLADE.
+-z    --no-hires  Pack the hi-res sprite pack separately.
+HELP
+    exit 0
+  fi
+
+  # Release build or development build
+  if [[ "$1" == "-r" || "$1" == "--release" ]]; then
+    cmthd='LZMA'
+    shift
+    continue
+  else
+    cmthd='Deflate'
+  fi
+
+  # Separate hi-res sprite pack
+  if [[ "$1" == "-z" || "$1" == "--no-hires" ]]; then
+    separate_hires_pack=1
+    shift
+    continue
+  fi
+
+  # Unrecognized argument
+  shift
+done
 
 git checkout master
 git pull origin master
 
+# Regular pk3 filename
 zipprefix="wolf_boa"
 zipcommit="$(git log -n 1 --format=%h)"
 zipname="$zipprefix-$zipcommit-$(git log -n 1 --date=short --format=%cd | sed 's/\([[:digit:]]\{4\}\)-\([[:digit:]]\{2\}\)-\([[:digit:]]\{1,2\}\)$/\1\2\3/').pk3"
 
-if [[ "$1" == "-r" || "$1" == "--release" ]]; then
-  cmthd='LZMA'
-  shift
+if [[ $separate_hires_pack -eq 0 ]]; then
+  7z a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' $zipname *
+  if [[ $? -eq 0 ]]; then mv $zipname ..; fi
 else
-  cmthd='Deflate'
+  # Hi-res sprite pack pk3 filename
+  hzipprefix="${zipprefix}_hd"
+  hzipname="$hzipprefix-$zipcommit-$(git log -n 1 --date=short --format=%cd | sed 's/\([[:digit:]]\{4\}\)-\([[:digit:]]\{2\}\)-\([[:digit:]]\{1,2\}\)$/\1\2\3/').pk3"
+
+  7z a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' -x!hires $zipname *
+  if [[ $? -eq 0 ]]; then mv $zipname ..; fi
+  7z a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc $hzipname hires
+  if [[ $? -eq 0 ]]; then mv $hzipname ..; fi
 fi
-
-# print -l **/*~*.bat~*.exe~.*~*.bak~source/*(#q.on) | zip -@ $zipname
-noglob 7z a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' $zipname *
-
-mv $zipname ..
-


### PR DESCRIPTION
Make Unix build script run on bash (the most common shell) instead of zsh.
Re-write argument parsing to support multiple, varied arguments.
Add a help screen.
Add a feature that allows the script to pack the hi-res stuff separately.

:notebook: The hi-res pack has the prefix "wolf_boa_hd".

The main benefits I see from packing the hi-res stuff separately is:
- It makes the hi-res stuff optional for now.
- Lower memory usage, and less chance of glitches or bugs in editors like SLADE. (I think the hi-res pack caused SLADE to glitch out on my end.)
- Slightly reduced main PK3 filesize.