### PR TITLE
Attempt to make build.sh runnable on Windows.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+if [[ -n "$(uname -s | grep -i 'MINGW\|CYGWIN\|MSYS')" ]]; then
+  # We're using Bash on Windows!
+  7za=./tools/7za.exe
+else
+  7za=7z
+fi
+
 separate_hires_pack=0
 
 # Parse arguments
@@ -49,15 +56,15 @@ zipcommit="$(git log -n 1 --format=%h)"
 zipname="$zipprefix-$zipcommit-$(git log -n 1 --date=short --format=%cd | sed 's/\([[:digit:]]\{4\}\)-\([[:digit:]]\{2\}\)-\([[:digit:]]\{1,2\}\)$/\1\2\3/').pk3"
 
 if [[ $separate_hires_pack -eq 0 ]]; then
-  7z a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' $zipname *
+  $7za a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' $zipname *
   if [[ $? -eq 0 ]]; then mv $zipname ..; fi
 else
   # Hi-res sprite pack pk3 filename
   hzipprefix="${zipprefix}_hd"
   hzipname="$hzipprefix-$zipcommit-$(git log -n 1 --date=short --format=%cd | sed 's/\([[:digit:]]\{4\}\)-\([[:digit:]]\{2\}\)-\([[:digit:]]\{1,2\}\)$/\1\2\3/').pk3"
 
-  7z a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' -x!hires $zipname *
+  $7za a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' -x!hires $zipname *
   if [[ $? -eq 0 ]]; then mv $zipname ..; fi
-  7z a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc $hzipname hires
+  $7za a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc $hzipname hires
   if [[ $? -eq 0 ]]; then mv $hzipname ..; fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ else
 fi
 
 separate_hires_pack=0
+cmthd='Deflate'
 
 # Parse arguments
 while [[ $# > 0 ]]; do
@@ -32,8 +33,6 @@ HELP
     cmthd='LZMA'
     shift
     continue
-  else
-    cmthd='Deflate'
   fi
 
   # Separate hi-res sprite pack


### PR DESCRIPTION
Detect Windows with uname and grep.
Add a variable for the 7z executable (on Windows, it's tools/7za.exe).

:notebook: Use the Git Shell to run build.sh on Windows.