### PR TITLE
Fix invalid variable name in Unix build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,9 @@
 
 if [[ -n "$(uname -s | grep -i 'MINGW\|CYGWIN\|MSYS')" ]]; then
   # We're using Bash on Windows!
-  7za=./tools/7za.exe
+  sevenzip=./tools/7za.exe
 else
-  7za=7z
+  sevenzip=7z
 fi
 
 separate_hires_pack=0
@@ -55,15 +55,15 @@ zipcommit="$(git log -n 1 --format=%h)"
 zipname="$zipprefix-$zipcommit-$(git log -n 1 --date=short --format=%cd | sed 's/\([[:digit:]]\{4\}\)-\([[:digit:]]\{2\}\)-\([[:digit:]]\{1,2\}\)$/\1\2\3/').pk3"
 
 if [[ $separate_hires_pack -eq 0 ]]; then
-  $7za a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' $zipname *
+  $sevenzip a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' $zipname *
   if [[ $? -eq 0 ]]; then mv $zipname ..; fi
 else
   # Hi-res sprite pack pk3 filename
   hzipprefix="${zipprefix}_hd"
   hzipname="$hzipprefix-$zipcommit-$(git log -n 1 --date=short --format=%cd | sed 's/\([[:digit:]]\{4\}\)-\([[:digit:]]\{2\}\)-\([[:digit:]]\{1,2\}\)$/\1\2\3/').pk3"
 
-  $7za a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' -x!hires $zipname *
+  $sevenzip a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' -x!hires $zipname *
   if [[ $? -eq 0 ]]; then mv $zipname ..; fi
-  $7za a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc $hzipname hires
+  $sevenzip a -tzip -mmt=on -mm=$cmthd -mx=9 -ssc $hzipname hires
   if [[ $? -eq 0 ]]; then mv $hzipname ..; fi
 fi


### PR DESCRIPTION
Apparently, variable names cannot begin with numbers.

EDIT: Pull request #100! Yay! :tada: