### PR TITLE
- Split Underwater postprocessing to its own file, in order to ease d…

### DIFF
--- a/boashaders.txt
+++ b/boashaders.txt
@@ -378,16 +378,3 @@ HardwareShader Sprite CLXTB0
 	Speed 1.3
 }
 
-//Underwater shader
-HardwareShader PostProcess scene {
-	Name "watershader"
-	Shader "shaders/Water.frag" 330
-	Uniform float waterFactor
-	Uniform float timer // placeholder?
-}
-
-HardwareShader PostProcess scene {
-	Name "waterzoomshader"
-	Shader "shaders/WaterZoom.frag" 330
-	Uniform float zoomFactor
-}

--- a/gldefs.txt
+++ b/gldefs.txt
@@ -1,5 +1,6 @@
 #include "boadefs.bm"
 #include "boashaders.txt" //mxd
+#include "ppshaders.txt"
 
 ////////////////////
 // SHADOWS - NASH //

--- a/ppshaders.txt
+++ b/ppshaders.txt
@@ -1,0 +1,14 @@
+//Underwater shader
+HardwareShader PostProcess scene {
+	Name "watershader"
+	Shader "shaders/Water.frag" 330
+	Uniform float waterFactor
+	Uniform float timer // placeholder?
+}
+
+HardwareShader PostProcess scene {
+	Name "waterzoomshader"
+	Shader "shaders/WaterZoom.frag" 330
+	Uniform float zoomFactor
+}
+


### PR DESCRIPTION
…istribution for GZDoom-only or for an optional addon for QZDoom.

Alright - so let me preface this by saying I don't know how all your distribution tools work but it should be pretty easy to adapt this. The intent behind this pull request is to make it easier for you to distribute for GZDoom-only, or optionally decide to distribute QZDoom as a stand-alone option.

All you have to do is for a GZDoom-specific version of the mod, you simply blank "ppshaders.txt" (make it a 0-byte file) - this prevents GZDoom from erroring out due to a script error on a QZDoom-specific feature.

Then, you have the same compiler tool create a new file with only "ppshaders.txt" included - this is to "flip on" the shaders, and allow them to work in QZDoom.

And later, if GZDoom does merge the post-process code, you can then simply revert the tools back to being as-is.

