### PR TITLE
Alternative fix for tracers

### DIFF
--- a/scripts/actors/tracers.txt
+++ b/scripts/actors/tracers.txt
@@ -44,19 +44,29 @@ class BulletTracer : FastProjectile
 	// Handling so that tracers won't hit actors that have the tracer's origin actor set as their master (or inherit from one that does)
 	override bool CanCollideWith(Actor other, bool passive)
 	{
-		int recursiontarget = 10; // Max number of levels to recurse if the master has a master, has a master, etc.
-		int recursionmaster = 10;
-
 		if (target)
 		{
 			Actor roottarget = target;
 			Actor rootmaster = other;
-			while (roottarget.master && recursiontarget) { roottarget = roottarget.master; recursiontarget--; }
-			while (rootmaster.master && recursionmaster) { rootmaster = rootmaster.master; recursionmaster--; }
+
+			Actor lasttarget = roottarget;
+			Actor lastmaster = rootmaster;
+
+			while (roottarget.master)
+			{
+				lasttarget = roottarget;
+				roottarget = roottarget.master;
+				if (lasttarget == roottarget) break;
+			}
+			while (rootmaster.master)
+			{
+				lastmaster = rootmaster;
+				rootmaster = rootmaster.master;
+				if (lastmaster == rootmaster) break;
+			}
 
 			if (roottarget && roottarget == rootmaster) { return false; }
 		}
-
 		return true;
 	}
 }


### PR DESCRIPTION
Keep track of the last target/last master, and break out of the loops based on those.