### PR TITLE
Make dying enemies set their target to the killer

### DIFF
--- a/scripts/actors/enemies/base.txt
+++ b/scripts/actors/enemies/base.txt
@@ -231,6 +231,7 @@ class Base : Actor
 	Default
 	{
 		Base.Shadow 1;
+		Activation THINGSPEC_Default | THINGSPEC_ThingTargets;
 	}
 
 	state A_LookThroughDisguise(int flags = 0, float minseedist = 0, float Range = 0, float maxheardist = 0, double fov = 0, statelabel label = "See")


### PR DESCRIPTION
This is so that a reference to the player in the training area can be retrieved in the scripts associated with the training area. I don't know if this will break anything else, so I'm opening a pull request for this change.