### PR TITLE
Make player Sherman repairable with repair kit

### DIFF
--- a/actors/items/mission.txt
+++ b/actors/items/mission.txt
@@ -257,21 +257,6 @@ ACTOR Cartridge53 : CompassItem
 	}
 }
 
-ACTOR RepairKit : CompassItem
-{
-	//$Title Repair Kit (electric)
-	Tag "$TAGREKIT"
-	Inventory.Icon EKPKA0
-	Inventory.PickupMessage "$ELECPAK"
-	Inventory.PickupSound "misc/gadget_pickup"
-	States
-	{
-	Spawn:
-		EKPK B -1
-		Stop
-	}
-}
-
 ACTOR Crank : CompassItem
 {
 	//$Title Crank (mech)

--- a/scripts/actors/enemies/tanks.txt
+++ b/scripts/actors/enemies/tanks.txt
@@ -170,13 +170,15 @@ class TankInterceptTarget : Actor
 {
 	Default
 	{
+		+BRIGHT
+		+INVISIBLE
 		+NOINTERACTION
 	}
 
 	States
 	{
 	Spawn:
-		TNT1 A -1;
+		EXCL A -1;
 		Stop;
 	}
 
@@ -185,7 +187,11 @@ class TankInterceptTarget : Actor
 		Super.Tick();
 		if (developer >= 1)
 		{
-			sprite = GetSpriteIndex('EXCL');
+			bInvisible = false;
+		}
+		else
+		{
+			bInvisible = true;
 		}
 	}
 }

--- a/scripts/actors/items/powerups.txt
+++ b/scripts/actors/items/powerups.txt
@@ -403,3 +403,65 @@ class RyanToken : DisguiseToken
 		DisguiseToken.NoTarget False; // Don't hide player from enemies
 	}
 }
+
+class PowerRepairing : Powerup
+{
+	Default
+	{
+		Powerup.Duration -15;
+		Powerup.Strength 3; // Per tic HP increase
+	}
+
+	override void DoEffect()
+	{
+		Super.DoEffect();
+		if (!Owner)
+		{
+			return;
+		}
+		else if (Owner is "ShermanPlayer")
+		{
+			// I would like to transfer the powerup to the tank body if the
+			// player exits the tank, but I don't know if that is even possible.
+			Owner.GiveBody(int(Strength), GetDefaultByType("ShermanPlayer").Health);
+		}
+		else
+		{
+			Destroy();
+		}
+	}
+}
+
+class RepairKit : CompassItem
+{
+	Default
+	{
+		//$Title Repair Kit (electric)
+		Tag "$TAGREKIT";
+		Inventory.Icon "EKPKA0";
+		Inventory.PickupMessage "$ELECPAK";
+		Inventory.PickupSound "misc/gadget_pickup";
+		Inventory.MaxAmount 3;
+	}
+
+	States
+	{
+	Spawn:
+		EKPK B -1;
+		Stop;
+	}
+
+	override bool Use(bool pickup)
+	{
+		if (Owner.FindInventory("PowerRepairing"))
+		{
+			return false;
+		}
+		if (Owner is "ShermanPlayer")
+		{
+			Inventory repairing = Owner.GiveInventoryType("PowerRepairing");
+			return true;
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
This adds a feature wherein you can repair your tank with a repair kit if you are driving the tank.

To repair your tank, select the repair kit while you are in the tank, and use it.