### PR TITLE
Fix achievement, add-on, and document regressions

### DIFF
--- a/_addons/source/confiscated_weapons/mapinfo.txt
+++ b/_addons/source/confiscated_weapons/mapinfo.txt
@@ -1,39 +1,4 @@
-// All this just so I could add to the list of equipment wipe in Astrostein, Part 2. I wish there's a cleaner way.
-// Update: I found a cleaner way.
-
-defaultmap
+gameinfo
 {
-	lightmode = 3
-	next = INTERMAP
-	Sky1 = "F_SKY1"
-	MapBackground = "MAP_BG"
-	nointermission
-	UnFreezeSinglePlayerConversations
-	ForceFallingDamage
-	MonsterFallingDamage
-	EnterPic = "CONBACK"
-	ExitPic = "CONBACK"
-
-	// Color Grading
-	EventHandlers = "ColorGradeEventHandler"
-
-	// Force breaking compatibility options off
-	compat_maskedmidtex = 0
-	compat_trace = 0
-
-	// Force SSAO being disabled in skyboxes
-	disableskyboxao
-
-	// Reduce the amount of data (and thus time) it takes to save your game
-	ForgetState
-}
-
-
-map C2M0_B lookup "C2M0"	//Tormentor667
-{
-	levelnum = 311
-	music = "C2M0BMUS"
-	cluster = 1
-	par = 2316
-	EventHandlers = "ConfisWeapsAstroWipe"
+	AddEventHandlers = "ConfisWeapsAstroWipe"
 }

--- a/_addons/source/confiscated_weapons/zscript.txt
+++ b/_addons/source/confiscated_weapons/zscript.txt
@@ -7,7 +7,11 @@ class ConfisWeapsAstroWipe : EventHandler
 	{
 			override void PlayerEntered (PlayerEvent e)
 			{
+				if (level.mapname != "C2M0_B") { return; }
+
 				let pPawn = players [e.PlayerNumber].mo;
+				if (!pPawn) { return; }
+
 				pPawn.A_TakeInventory ("Kabar", 0x7FFFFFFF);
 				pPawn.A_TakeInventory ("BrassKnucks", 0x7FFFFFFF);
 				pPawn.A_TakeInventory ("ThrowingKnife", 0x7FFFFFFF);

--- a/scripts/actors/enemies/base.zs
+++ b/scripts/actors/enemies/base.zs
@@ -2526,7 +2526,7 @@ class Nazi : Base
 			if (bBoss && inflictor is "KickPuff") { AchievementTracker.CheckAchievement(source.PlayerNumber(), AchievementTracker.ACH_DISGRACE); }
 
 			// Achievement for killing enemies with the shovel
-			if (inflictor is "ShovelPuff" && Default.species == "Nazi" && !(self is "MutantStandard")) { AchievementTracker.CheckAchievement(source.PlayerNumber(), AchievementTracker.ACH_SHOVEL); }
+			if (inflictor && inflictor.GetClass() == "ShovelPuff" && Default.species == "Nazi" && !(self is "MutantStandard")) { AchievementTracker.CheckAchievement(source.PlayerNumber(), AchievementTracker.ACH_SHOVEL); }
 
 			// Achievement for sniping over long range
 			if (inflictor && inflictor is "Kar98KTracer2" && Distance3D(source) >= 6000) { AchievementTracker.CheckAchievement(source.PlayerNumber(), AchievementTracker.ACH_CLEARSHOT); }
@@ -2561,7 +2561,7 @@ class Nazi : Base
 
 		String currentDamage = (inflictor && inflictor.paintype) ? inflictor.paintype : mod; // Get the damage type
 
-		if (currentDamage ~== "SilentKnifeAttack" && !bBoss) // If the attack was with the knife (and this is not a boss actor - they can't be one-hit killed!)
+		if (currentDamage ~== "SilentKnifeAttack" && !bBoss && !bInvulnerable && !bNoDamage) // Bosses and damage-immune actors can't be one-hit killed
 		{
 			if (bFriendly)
 			{

--- a/scripts/actors/player.zs
+++ b/scripts/actors/player.zs
@@ -1351,7 +1351,16 @@ class BoAPlayer : PlayerPawn
 		{
 			if (mod == "Drowning") { tracker.SetBit(tracker.records[tracker.STAT_LIQUIDDEATH].value, 0); }
 			else if (mod == "Lava") { tracker.SetBit(tracker.records[tracker.STAT_LIQUIDDEATH].value, 1); }
-			else if (mod == "MutantPoisonAmbience") { tracker.SetBit(tracker.records[tracker.STAT_LIQUIDDEATH].value, 2); }
+			else if (
+				mod == "MutantPoisonAmbience" &&
+				(
+					GetTextureMod(TexMan.GetName(floorpic)) == "MutantPoisonAmbience" ||
+					(underwater && GetTextureMod(TexMan.GetName(cursec.GetTexture(Sector.ceiling))) == "MutantPoisonAmbience")
+				)
+			)
+			{
+				tracker.SetBit(tracker.records[tracker.STAT_LIQUIDDEATH].value, 2);
+			}
 
 			AchievementTracker.CheckAchievement(PlayerNumber(), AchievementTracker.ACH_LIQUIDDEATH);
 		}

--- a/scripts/eventhandlers/Tracker.zs
+++ b/scripts/eventhandlers/Tracker.zs
@@ -984,13 +984,21 @@ class AchievementTracker : StaticEventHandler
 		PersistentAchievementTracker ptracker = PersistentAchievementTracker(EventHandler.Find("PersistentAchievementTracker"));
 		if (!ptracker) { return; }
 
+		keycount = ptracker.keycount;
+
 		for (int i = 0; i < MAXPLAYERS; i++)
 		{
 			pistolshots[i] = ptracker.pistolshots[i];
 			knifekills[i] = ptracker.knifekills[i];
+			damaged[i] = ptracker.damaged[i];
+			reloads[i] = ptracker.reloads[i];
+			manualreloads[i] = ptracker.manualreloads[i];
 			surrenders[i] = ptracker.surrenders[i];
+			grenades[i] = ptracker.grenades[i];
 			totalgrenades[i] = ptracker.totalgrenades[i];
 			exhaustion[i] = ptracker.exhaustion[i];
+			lastminedeath[i] = ptracker.lastminedeath[i];
+			minedeaths[i] = ptracker.minedeaths[i];
 			zombies[i] = ptracker.zombies[i];
 			fieldkits[i] = ptracker.fieldkits[i];
 			chests[i] = ptracker.chests[i];
@@ -1003,6 +1011,11 @@ class AchievementTracker : StaticEventHandler
 			{
 				weapons[i][w] = ptracker.weapons[i][w];
 			}
+
+			for (int s = 0; s < 2; s++)
+			{
+				shots[i][s] = ptracker.shots[i][s];
+			}
 		}
 	}
 
@@ -1011,13 +1024,21 @@ class AchievementTracker : StaticEventHandler
 		PersistentAchievementTracker ptracker = PersistentAchievementTracker(EventHandler.Find("PersistentAchievementTracker"));
 		if (!ptracker) { return; }
 
+		ptracker.keycount = keycount;
+
 		for (int i = 0; i < MAXPLAYERS; i++)
 		{
 			ptracker.pistolshots[i] = pistolshots[i];
 			ptracker.knifekills[i] = knifekills[i];
+			ptracker.damaged[i] = damaged[i];
+			ptracker.reloads[i] = reloads[i];
+			ptracker.manualreloads[i] = manualreloads[i];
 			ptracker.surrenders[i] = surrenders[i];
+			ptracker.grenades[i] = grenades[i];
 			ptracker.totalgrenades[i] = totalgrenades[i];
 			ptracker.exhaustion[i] = exhaustion[i];
+			ptracker.lastminedeath[i] = lastminedeath[i];
+			ptracker.minedeaths[i] = minedeaths[i];
 			ptracker.zombies[i] = zombies[i];
 			ptracker.fieldkits[i] = fieldkits[i];
 			ptracker.chests[i] = chests[i];
@@ -1029,6 +1050,11 @@ class AchievementTracker : StaticEventHandler
 			for (int w = 0; w < 16; w++)
 			{
 				ptracker.weapons[i][w] = weapons[i][w];
+			}
+
+			for (int s = 0; s < 2; s++)
+			{
+				ptracker.shots[i][s] = shots[i][s];
 			}
 		}
 	}
@@ -1045,9 +1071,16 @@ class PersistentAchievementTracker : EventHandler
 {
 	int pistolshots[MAXPLAYERS];
 	int knifekills[MAXPLAYERS];
+	int damaged[MAXPLAYERS];
+	int reloads[MAXPLAYERS];
+	int manualreloads[MAXPLAYERS];
 	int surrenders[MAXPLAYERS];
+	int grenades[MAXPLAYERS];
 	int totalgrenades[MAXPLAYERS];
 	int exhaustion[MAXPLAYERS];
+	int lastminedeath[MAXPLAYERS];
+	int minedeaths[MAXPLAYERS];
+	int shots[MAXPLAYERS][2];
 	int zombies[MAXPLAYERS];
 	bool weapons[MAXPLAYERS][16];
 	int fieldkits[MAXPLAYERS];
@@ -1055,5 +1088,6 @@ class PersistentAchievementTracker : EventHandler
 	int deadwounded[MAXPLAYERS];
 	int gibs[MAXPLAYERS];
 	int coins[MAXPLAYERS];
+	int keycount;
 	int shovelkills[MAXPLAYERS];
 }

--- a/scripts/menus/interface.zs
+++ b/scripts/menus/interface.zs
@@ -639,10 +639,11 @@ class ViewItem : BoAMenu
 				else { break; }
 			}		
 
-			double pages = count / maxlines;
+			double pages = double(count) / maxlines;
 
-			maxpages = int(pages);  // maxpages is an integer, but make sure to always round up if there was even a small amount of overflow
+			maxpages = int(pages);  // Round up to get the number of pages
 			if (maxpages < pages) { maxpages++; }
+			maxpages = max(0, maxpages - 1); // maxpages is the zero-based index of the final page
 		}
 
 		// Hint message


### PR DESCRIPTION
## Summary

- Count only exact `ShovelPuff` kills toward the shovel achievement and preserve damage immunity during silent knife attacks.
- Require an actual mutant poison pool before recording the poison condition for Liquid Death.
- Preserve all level-specific achievement tracking state across savegame loads.
- Register the Confiscated Weapons inventory wipe globally with a `C2M0_B` guard instead of overriding the map definition.
- Correct document pagination so an exact page boundary does not create a blank trailing page.

## Root causes

Several achievement checks relied on inherited actor classes or shared damage types, which made unrelated attacks satisfy their conditions. Level-specific achievement fields were not mirrored into the persistent tracker before savegame restoration. The Confiscated Weapons add-on duplicated the full `C2M0_B` MAPINFO block only to attach an event handler, allowing its stale map definition to replace the current exit configuration. Document pagination stored a page count in a variable used as the zero-based final-page index.

## Impact

Knife, shovel, Liquid Death, Impenetrable, reload, grenade, accuracy, mine, and key-related achievement state now behaves consistently. Loading a save no longer resets level-specific achievement progress. The Confiscated Weapons add-on no longer breaks the `C2M0_B` exit, and localized documents no longer gain an empty final page at exact page boundaries.

## Validation

- Loaded the main repository and Confiscated Weapons add-on through UZDoom 4.14.3 up to and beyond `LoadActors` without ZScript or MAPINFO parser errors.
- Ran targeted assertions for all six regression paths, including document pagination boundary cases.
- Ran `git diff --check`.

Fixes #1345
Fixes #1547
Fixes #1597
Fixes #1601
Fixes #1622
Fixes #1666
